### PR TITLE
Renamed vairables to be in accordance with the Lua Style Guide

### DIFF
--- a/1-tiles/a-quads-and-images/main.lua
+++ b/1-tiles/a-quads-and-images/main.lua
@@ -1,24 +1,24 @@
 
 function love.load()
   
-  Tileset = love.graphics.newImage('countryside.png')
+  tileset = love.graphics.newImage('countryside.png')
   
   local tileW, tileH = 32,32
-  local tilesetW, tilesetH = Tileset:getWidth(), Tileset:getHeight()
+  local tilesetW, tilesetH = tileset:getWidth(), tileset:getHeight()
   
-  GrassQuad = love.graphics.newQuad(0,  0, tileW, tileH, tilesetW, tilesetH)
-  BoxQuad = love.graphics.newQuad(32, 0, tileW, tileH, tilesetW, tilesetH)
+  grassQuad = love.graphics.newQuad(0,  0, tileW, tileH, tilesetW, tilesetH)
+  boxQuad = love.graphics.newQuad(32, 0, tileW, tileH, tilesetW, tilesetH)
 
 end
 
 function love.draw()
-  love.graphics.draw(Tileset, GrassQuad, 368, 268)
-  love.graphics.draw(Tileset, GrassQuad, 400, 268)
-  love.graphics.draw(Tileset, GrassQuad, 432, 268)
-  love.graphics.draw(Tileset, GrassQuad, 368, 300)
-  love.graphics.draw(Tileset, BoxQuad  , 400, 300)
-  love.graphics.draw(Tileset, GrassQuad, 432, 300)
-  love.graphics.draw(Tileset, GrassQuad, 368, 332)
-  love.graphics.draw(Tileset, GrassQuad, 400, 332)
-  love.graphics.draw(Tileset, GrassQuad, 432, 332)
+  love.graphics.draw(tileset, grassQuad, 368, 268)
+  love.graphics.draw(tileset, grassQuad, 400, 268)
+  love.graphics.draw(tileset, grassQuad, 432, 268)
+  love.graphics.draw(tileset, grassQuad, 368, 300)
+  love.graphics.draw(tileset, boxQuad  , 400, 300)
+  love.graphics.draw(tileset, grassQuad, 432, 300)
+  love.graphics.draw(tileset, grassQuad, 368, 332)
+  love.graphics.draw(tileset, grassQuad, 400, 332)
+  love.graphics.draw(tileset, grassQuad, 432, 332)
 end

--- a/1-tiles/b-tables-and-loops/main.lua
+++ b/1-tiles/b-tables-and-loops/main.lua
@@ -2,20 +2,20 @@
 
 function love.load()
 
-  TileW, TileH = 32,32
+  tileW, tileH = 32,32
   
-  Tileset = love.graphics.newImage('countryside.png')
+  tileSet = love.graphics.newImage('countryside.png')
   
-  local tilesetW, tilesetH = Tileset:getWidth(), Tileset:getHeight()
+  local tilesetW, tilesetH = tileSet:getWidth(), tileSet:getHeight()
   
-  Quads = {
-    love.graphics.newQuad(0,   0, TileW, TileH, tilesetW, tilesetH), -- 1 = grass
-    love.graphics.newQuad(32,  0, TileW, TileH, tilesetW, tilesetH), -- 2 = box
-    love.graphics.newQuad(0,  32, TileW, TileH, tilesetW, tilesetH), -- 3 = flowers
-    love.graphics.newQuad(32, 32, TileW, TileH, tilesetW, tilesetH)  -- 4 = boxtop
+  quads = {
+    love.graphics.newQuad(0,   0, tileW, tileH, tilesetW, tilesetH), -- 1 = grass
+    love.graphics.newQuad(32,  0, tileW, tileH, tilesetW, tilesetH), -- 2 = box
+    love.graphics.newQuad(0,  32, tileW, tileH, tilesetW, tilesetH), -- 3 = flowers
+    love.graphics.newQuad(32, 32, tileW, tileH, tilesetW, tilesetH)  -- 4 = boxtop
   }
   
-  TileTable = {
+  tileTable = {
   
      { 4,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,4 },
      { 4,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,4 },
@@ -40,13 +40,13 @@ function love.load()
 end
 
 function love.draw()
-  for rowIndex=1, #TileTable do
-    local row = TileTable[rowIndex]
+  for rowIndex=1, #tileTable do
+    local row = tileTable[rowIndex]
     for columnIndex=1, #row do
       local number = row[columnIndex]
-      local x = (columnIndex-1)*TileW
-      local y = (rowIndex-1)*TileH
-      love.graphics.draw(Tileset, Quads[number], x, y)
+      local x = (columnIndex-1)*tileW
+      local y = (rowIndex-1)*tileH
+      love.graphics.draw(tileSet, quads[number], x, y)
     end
   end
 end

--- a/1-tiles/c-more-tables/main.lua
+++ b/1-tiles/c-more-tables/main.lua
@@ -1,10 +1,10 @@
 function love.load()
 
-  TileW, TileH = 32,32
+  tileW, tileH = 32,32
   
-  Tileset = love.graphics.newImage('countryside.png')
+  tileset = love.graphics.newImage('countryside.png')
   
-  local tilesetW, tilesetH = Tileset:getWidth(), Tileset:getHeight()
+  local tilesetW, tilesetH = tileset:getWidth(), tileset:getHeight()
   
   local quadInfo = { 
     {  0,  0 }, -- 1 = grass 
@@ -13,10 +13,10 @@ function love.load()
     { 32, 32 }, -- 4 = boxTop
   }
 
-  Quads = {}
+  quads = {}
   for i,info in ipairs(quadInfo) do
     -- info[1] = x, info[2] = y
-    Quads[i] = love.graphics.newQuad(info[1], info[2], TileW, TileH, tilesetW, tilesetH)
+    quads[i] = love.graphics.newQuad(info[1], info[2], tileW, tileH, tilesetW, tilesetH)
   end
   
   TileTable = {
@@ -48,8 +48,8 @@ function love.draw()
 
   for rowIndex,row in ipairs(TileTable) do
     for columnIndex,number in ipairs(row) do
-      local x,y = (columnIndex-1)*TileW, (rowIndex-1)*TileH
-      love.graphics.draw(Tileset, Quads[number], x, y)
+      local x,y = (columnIndex-1)*tileW, (rowIndex-1)*tileH
+      love.graphics.draw(tileset, quads[number], x, y)
     end
   end
 

--- a/1-tiles/d-strings/main.lua
+++ b/1-tiles/d-strings/main.lua
@@ -1,10 +1,10 @@
 function love.load()
 
-  TileW, TileH = 32,32
+  tileW, tileH = 32,32
   
-  Tileset = love.graphics.newImage('countryside.png')
+  tileset = love.graphics.newImage('countryside.png')
   
-  local tilesetW, tilesetH = Tileset:getWidth(), Tileset:getHeight()
+  local tilesetW, tilesetH = tileset:getWidth(), tileset:getHeight()
 
   local quadInfo = { 
     { ' ', 0,   0 }, -- 1 = grass 
@@ -13,10 +13,10 @@ function love.load()
     { '^', 32, 32 }  -- 4 = boxTop
   }
 
-  Quads = {}
+  quads = {}
   for _,info in ipairs(quadInfo) do
     -- info[1] = character, info[2]= x, info[3] = y
-    Quads[info[1]] = love.graphics.newQuad(info[2], info[3], TileW, TileH, tilesetW, tilesetH)
+    quads[info[1]] = love.graphics.newQuad(info[2], info[3], tileW, tileH, tilesetW, tilesetH)
   end
 
 
@@ -64,8 +64,8 @@ function love.draw()
   
   for columnIndex,column in ipairs(TileTable) do
     for rowIndex,char in ipairs(column) do
-      local x,y = (columnIndex-1)*TileW, (rowIndex-1)*TileH
-      love.graphics.draw(Tileset, Quads[char], x, y)
+      local x,y = (columnIndex-1)*tileW, (rowIndex-1)*tileH
+      love.graphics.draw(tileset, quads[char], x, y)
     end
   end
 

--- a/1-tiles/e-functions/main.lua
+++ b/1-tiles/e-functions/main.lua
@@ -1,30 +1,30 @@
 
-function loadMap(tileW, tileH, tilesetPath, tileString, quadInfo)
+function loadMap(tileWidth, tileHeight, tilesetPath, tileString, quadInfo)
   
-  TileW = tileW
-  TileH = tileH
-  Tileset = love.graphics.newImage(tilesetPath)
+  tileW = tileWidth
+  tileH = tileHeight
+  tileset = love.graphics.newImage(tilesetPath)
   
-  local tilesetW, tilesetH = Tileset:getWidth(), Tileset:getHeight()
-  Quads = {}
+  local tilesetW, tilesetH = tileset:getWidth(), tileset:getHeight()
+  quads = {}
   
   for _,info in ipairs(quadInfo) do
     -- info[1] = the character, info[2] = x, info[3] = y
-    Quads[info[1]] = love.graphics.newQuad(info[2], info[3], TileW,  TileH, tilesetW, tilesetH)
+    quads[info[1]] = love.graphics.newQuad(info[2], info[3], tileW,  tileH, tilesetW, tilesetH)
   end
   
-  TileTable = {}
+  tileTable = {}
   
   local width = #(tileString:match("[^\n]+"))
 
-  for x = 1,width,1 do TileTable[x] = {} end
+  for x = 1,width,1 do tileTable[x] = {} end
 
   local rowIndex,columnIndex = 1,1
   for row in tileString:gmatch("[^\n]+") do
     assert(#row == width, 'Map is not aligned: width of row ' .. tostring(rowIndex) .. ' should be ' .. tostring(width) .. ', but it is ' .. tostring(#row))
     columnIndex = 1
     for character in row:gmatch(".") do
-      TileTable[columnIndex][rowIndex] = character
+      tileTable[columnIndex][rowIndex] = character
       columnIndex = columnIndex + 1
     end
     rowIndex=rowIndex+1
@@ -33,10 +33,10 @@ function loadMap(tileW, tileH, tilesetPath, tileString, quadInfo)
 end
 
 function drawMap()
-  for columnIndex,column in ipairs(TileTable) do
+  for columnIndex,column in ipairs(tileTable) do
     for rowIndex,char in ipairs(column) do
-      local x,y = (columnIndex-1)*TileW, (rowIndex-1)*TileH
-      love.graphics.draw(Tileset, Quads[ char ], x, y)
+      local x,y = (columnIndex-1)*tileW, (rowIndex-1)*tileH
+      love.graphics.draw(tileset, quads[ char ], x, y)
     end
   end
 end

--- a/1-tiles/f-files/map-functions.lua
+++ b/1-tiles/f-files/map-functions.lua
@@ -2,33 +2,33 @@ function loadMap(path)
   love.filesystem.load(path)() -- attention! extra parenthesis
 end
 
-function newMap(tileW, tileH, tilesetPath, tileString, quadInfo)
+function newMap(tileWidth, tileHeight, tilesetPath, tileString, quadInfo)
   
-  TileW = tileW
-  TileH = tileH
-  Tileset = love.graphics.newImage(tilesetPath)
+  tileW = tileWidth
+  tileH = tileHeight
+  tileset = love.graphics.newImage(tilesetPath)
   
-  local tilesetW, tilesetH = Tileset:getWidth(), Tileset:getHeight()
+  local tilesetW, tilesetH = tileset:getWidth(), tileset:getHeight()
   
-  Quads = {}
+  quads = {}
   
   for _,info in ipairs(quadInfo) do
     -- info[1] = the character, info[2] = x, info[3] = y
-    Quads[info[1]] = love.graphics.newQuad(info[2], info[3], TileW,  TileH, tilesetW, tilesetH)
+    quads[info[1]] = love.graphics.newQuad(info[2], info[3], tileW,  tileH, tilesetW, tilesetH)
   end
   
-  TileTable = {}
+  tileTable = {}
   
   local width = #(tileString:match("[^\n]+"))
 
-  for x = 1,width,1 do TileTable[x] = {} end
+  for x = 1,width,1 do tileTable[x] = {} end
 
   local rowIndex,columnIndex = 1,1
   for row in tileString:gmatch("[^\n]+") do
     assert(#row == width, 'Map is not aligned: width of row ' .. tostring(rowIndex) .. ' should be ' .. tostring(width) .. ', but it is ' .. tostring(#row))
     columnIndex = 1
     for character in row:gmatch(".") do
-      TileTable[columnIndex][rowIndex] = character
+      tileTable[columnIndex][rowIndex] = character
       columnIndex = columnIndex + 1
     end
     rowIndex=rowIndex+1
@@ -37,9 +37,9 @@ function newMap(tileW, tileH, tilesetPath, tileString, quadInfo)
 end
 
 function drawMap()
-  for x,column in ipairs(TileTable) do
+  for x,column in ipairs(tileTable) do
     for y,char in ipairs(column) do
-      love.graphics.draw(Tileset, Quads[ char ] , (x-1)*TileW, (y-1)*TileH)
+      love.graphics.draw(tileset, quads[ char ] , (x-1)*tileW, (y-1)*tileH)
     end
   end
 end


### PR DESCRIPTION
I saw that in the later parts of the tutorial, such as in part _g-global-variables_ you began to use camelCase with the first character of the variable being lowercase. This was in discordance with the beginning of the tutorial. This commit rectifies that fact.
